### PR TITLE
Add support for path endpoints

### DIFF
--- a/src/mdm-catalogue-item.model.ts
+++ b/src/mdm-catalogue-item.model.ts
@@ -106,3 +106,46 @@ export interface AnnotationCreatePayload extends Payload {
 export interface AnnotationChildCreatePayload extends Payload {
   description: string;
 }
+
+/**
+ * Represents all the domain types that can be used with the Mauro path APIs.
+ */
+export type PathableDomainType =
+  'annotations'
+  | 'authorities'
+  | 'classifiers'
+  | 'codeSets'
+  | 'catalogueUsers'
+  | 'dataClasses'
+  | 'dataClassComponents'
+  | 'dataElement'
+  | 'dataElementComponents'
+  | 'dataFlows'
+  | 'dataModels'
+  | 'enumerationTypes'
+  | 'edits'
+  | 'enumerationValues'
+  | 'folders'
+  | 'groupRoles'
+  | 'metadata'
+  | 'referenceDataElements'
+  | 'referenceDataModels'
+  | 'referenceEnumerationTypes'
+  | 'referenceDataValues'
+  | 'referenceEnumerationValues'
+  | 'referenceFiles'
+  | 'ruleRepresentations'
+  | 'referenceSummaryMetadata'
+  | 'referenceSummaryMetadataReports'
+  | 'rules'
+  | 'semanticLinks'
+  | 'summaryMetadata'
+  | 'summaryMetadataReports'
+  | 'terminologies'
+  | 'terms'
+  | 'termRelationships'
+  | 'termRelationshipTypes'
+  | 'userGroups'
+  | 'userImageFiles'
+  | 'versionedFolders'
+  | 'versionLinks';

--- a/src/mdm-catalogue-item.model.ts
+++ b/src/mdm-catalogue-item.model.ts
@@ -118,7 +118,7 @@ export type PathableDomainType =
   | 'catalogueUsers'
   | 'dataClasses'
   | 'dataClassComponents'
-  | 'dataElement'
+  | 'dataElements'
   | 'dataElementComponents'
   | 'dataFlows'
   | 'dataModels'

--- a/src/mdm-catalogue-item.resource.ts
+++ b/src/mdm-catalogue-item.resource.ts
@@ -17,7 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 
-import { AnnotationChildCreatePayload, AnnotationCreatePayload, ReferenceFile, ReferenceFileCreatePayload } from './mdm-catalogue-item.model';
+import { AnnotationChildCreatePayload, AnnotationCreatePayload, PathableDomainType, ReferenceFile, ReferenceFileCreatePayload } from './mdm-catalogue-item.model';
 import { RequestSettings, QueryParameters, ModelDomainType, Uuid, FilterQueryParameters } from './mdm-common.model';
 import { MdmResource } from './mdm-resource';
 
@@ -421,6 +421,61 @@ export class MdmCatalogueItemResource extends MdmResource {
   removeRulesRepresentation(catalogueItemDomainType: string | ModelDomainType, catalogueItemId: string, ruleId: string, representationId: string, queryStringParams?: QueryParameters, restHandlerOptions?: RequestSettings) {
     const url = `${this.apiEndpoint}/${catalogueItemDomainType}/${catalogueItemId}/rules/${ruleId}/representations/${representationId}`;
     return this.simpleDelete(url, queryStringParams, restHandlerOptions);
+  }
+
+  // Paths
+
+  /**
+   * `HTTP GET` - Gets a catalogue item by its path.
+   *
+   * @param domainType The domain type of the parent catalogue item.
+   * @param path The path to the catalogue item. Use Mauro pathing syntax. This will automatically be URL encoded before
+   * submitting.
+   * @param query Optional query parameters, if required.
+   * @param options Optional REST handler parameters, if required.
+   * @returns The result of the `GET` request.
+   *
+   * `200 OK` - will return an {@link MdmResponse} containing the catalogue item requested. The type of object in the response
+   * body will depend on the path requested.
+   *
+   * @example
+   *
+   * ```ts
+   * getPath('dataModels', 'dm:My Data Model')
+   * getPath('codeSets', 'cs:My Code Set')
+   * getPath('folders', 'fo:My Folder')
+   * ```
+   */
+  getPath(domainType: PathableDomainType, path: string, query?: QueryParameters, options?: RequestSettings) {
+    const encodedPath = encodeURIComponent(path);
+    const url = `${this.apiEndpoint}/${domainType}/path/${encodedPath}`;
+    return this.simpleGet(url, query, options);
+  }
+
+   /**
+    * `HTTP GET` - Gets a catalogue item by its path, where the catalogue item is a child of a specific parent item.
+    *
+    * @param domainType The domain type of the parent catalogue item.
+    * @param id The unique identifier of the parent catalogue item.
+    * @param path The path to the child catalogue item. Use Mauro pathing syntax. This will automatically be URL encoded before
+    * submitting.
+    * @param query Optional query parameters, if required.
+    * @param options Optional REST handler parameters, if required.
+    * @returns The result of the `GET` request.
+    *
+    * `200 OK` - will return an {@link MdmResponse} containing the catalogue item requested. The type of object in the response
+    * body will depend on the path requested.
+    *
+    * @example
+    *
+    * ```ts
+    * getPath('folders', '52c8a239-afad-4041-ac9f-932b89525c0d', 'dm:My Data Model')
+    * ```
+    */
+  getPathFromParent(domainType: PathableDomainType, id: Uuid, path: string, query?: QueryParameters, options?: RequestSettings) {
+    const encodedPath = encodeURIComponent(path);
+    const url = `${this.apiEndpoint}/${domainType}/${id}/path/${encodedPath}`;
+    return this.simpleGet(url, query, options);
   }
 
 }

--- a/src/mdm-code-set.resource.ts
+++ b/src/mdm-code-set.resource.ts
@@ -246,6 +246,10 @@ export class MdmCodeSetResource extends MdmResource {
    * @returns The result of the `GET` request.
    *
    * `200 OK` - will return a {@link CodeSetDetailResponse} containing a {@link CodeSetDetail} object.
+   *
+   * This function does allow either an ID or a path string, but should ideally be used only for IDs. For using paths,
+   * see the {@link MdmCatalogueItemResource.getPath()} function instead; there are no guarantees this function will support
+   * paths in the future, but will currently be supported for backwards compatibility.
    */
   get(codeSetId: Uuid | string, query?: QueryParameters, options?: RequestSettings) {
     let url = '';

--- a/src/mdm-data-class.resource.ts
+++ b/src/mdm-data-class.resource.ts
@@ -153,6 +153,10 @@ export class MdmDataClassResource extends MdmResource {
    * @returns The result of the `GET` request.
    *
    * `200 OK` - will return a {@link DataClassDetailResponse} containing a {@link DataClassDetail} object.
+   *
+   * This function does allow either an ID or a path string, but should ideally be used only for IDs. For using paths,
+   * see the {@link MdmCatalogueItemResource.getPath()} function instead; there are no guarantees this function will support
+   * paths in the future, but will currently be supported for backwards compatibility.
    */
   getChildDataClass(dataModelId: Uuid, dataClassId: Uuid, childDataClassId: Uuid, query?: QueryParameters, options?: RequestSettings) {
     let url = '';

--- a/src/mdm-data-element.resource.ts
+++ b/src/mdm-data-element.resource.ts
@@ -126,6 +126,10 @@ export class MdmDataElementResource extends MdmResource {
    * @returns The result of the `GET` request.
    *
    * `200 OK` - will return a {@link DataElementDetailResponse} containing a {@link DataElementDetail} object.
+   *
+   * This function does allow either an ID or a path string, but should ideally be used only for IDs. For using paths,
+   * see the {@link MdmCatalogueItemResource.getPath()} function instead; there are no guarantees this function will support
+   * paths in the future, but will currently be supported for backwards compatibility.
    */
   get(dataModelId: Uuid, dataClassId: Uuid, dataElementId: Uuid | string, query?: QueryParameters, options?: RequestSettings) {
     let url = '';

--- a/src/mdm-data-model.resource.ts
+++ b/src/mdm-data-model.resource.ts
@@ -510,6 +510,10 @@ export class MdmDataModelResource extends MdmResource {
    * @returns The result of the `GET` request.
    *
    * `200 OK` - will return a {@link DataModelDetailResponse} containing a {@link DataModelDetail} object.
+   *
+   * This function does allow either an ID or a path string, but should ideally be used only for IDs. For using paths,
+   * see the {@link MdmCatalogueItemResource.getPath()} function instead; there are no guarantees this function will support
+   * paths in the future, but will currently be supported for backwards compatibility.
    */
   get(dataModelId: Uuid, query?: QueryParameters, options?: RequestSettings) {
     let url = '';

--- a/src/mdm-data-type.resource.ts
+++ b/src/mdm-data-type.resource.ts
@@ -108,6 +108,10 @@ export class MdmDataTypeResource extends MdmResource {
    * @returns The result of the `GET` request.
    *
    * `200 OK` - will return a {@link DataTypeDetailResponse} containing a {@link DataTypeDetail} object.
+   *
+   * This function does allow either an ID or a path string, but should ideally be used only for IDs. For using paths,
+   * see the {@link MdmCatalogueItemResource.getPath()} function instead; there are no guarantees this function will support
+   * paths in the future, but will currently be supported for backwards compatibility.
    */
   get(dataModelId: Uuid, dataTypeId: Uuid | string, query?: QueryParameters, options?: RequestSettings) {
     let url = '';

--- a/src/mdm-term.resource.ts
+++ b/src/mdm-term.resource.ts
@@ -133,6 +133,10 @@ export class MdmTermResource extends MdmResource {
    * @returns The result of the `GET` request.
    *
    * `200 OK` - will return a {@link TermDetailResponse} containing a {@link TermDetail} object.
+   *
+   * This function does allow either an ID or a path string, but should ideally be used only for IDs. For using paths,
+   * see the {@link MdmCatalogueItemResource.getPath()} function instead; there are no guarantees this function will support
+   * paths in the future, but will currently be supported for backwards compatibility.
    */
   get(terminologyId: Uuid, termId: Uuid | string, query?: QueryParameters, options?: RequestSettings) {
     let url = '';

--- a/src/mdm-terminology.resource.ts
+++ b/src/mdm-terminology.resource.ts
@@ -230,6 +230,10 @@ export class MdmTerminologyResource extends MdmResource {
    * @returns The result of the `GET` request.
    *
    * `200 OK` - will return a {@link TerminologyDetailResponse} containing a {@link TerminologyDetail} object.
+   *
+   * This function does allow either an ID or a path string, but should ideally be used only for IDs. For using paths,
+   * see the {@link MdmCatalogueItemResource.getPath()} function instead; there are no guarantees this function will support
+   * paths in the future, but will currently be supported for backwards compatibility.
    */
   get(terminologyId: Uuid, query?: QueryParameters, options?: RequestSettings) {
     let url = '';


### PR DESCRIPTION
Existing functions did try to include the `/path` endpoints, but they tried to be either IDs or paths, plus they did not cover all possible domain types.

@olliefreeman , @joe-crawford  - please could you briefly review to ensure I've got the correct domain type names (and pluralised correctly to be included in the URLs).