### PR TITLE
Updated Data Model type definitions

### DIFF
--- a/src/mdm-common.model.ts
+++ b/src/mdm-common.model.ts
@@ -426,7 +426,7 @@ export interface SearchQueryParameters extends SortParameters, PageParameters, Q
   /**
    * The term(s) to search for in the catalogue.
    */
-  searchTerm?: string;   
+  searchTerm?: string;
 
   /**
    * State whether to only search for terms within labels of catalogue items.

--- a/src/mdm-common.model.ts
+++ b/src/mdm-common.model.ts
@@ -422,33 +422,11 @@ export interface CatalogueItemReference {
 /**
  * Represents the standard query parameters to use for a search operation.
  */
-export interface SearchQueryParameters extends QueryParameters {
+export interface SearchQueryParameters extends SortParameters, PageParameters, QueryParameters {
   /**
    * The term(s) to search for in the catalogue.
    */
-  searchTerm?: string;
-
-  /**
-   * Specify the property to sort by e.g. 'label'.
-   */
-  sort?: string;
-
-  /**
-   * Specify the order to sort by.
-   */
-  order?: 'asc' | 'desc';
-
-  /**
-   * Specify the maximum number of results to return in a single page of results.
-   */
-  max?: number;
-
-  /**
-   * Specify the offset to start search results from.
-   *
-   * When combined with {@link max}, this can be used to page results.
-   */
-  offset?: number;
+  searchTerm?: string;   
 
   /**
    * State whether to only search for terms within labels of catalogue items.

--- a/src/mdm-data-class.model.ts
+++ b/src/mdm-data-class.model.ts
@@ -45,13 +45,13 @@ export type DataClassIndexResponse = MdmIndexResponse<DataClass>;
 export type DataClassDetailResponse = MdmResponse<DataClassDetail>;
 
 /**
- * Represents hierarchy information for a Data Class.
+ * Represents information for a Data Class relating to a hierarchy.
  */
-export interface DataClassHierarchy {
+export interface DataClassNode {
   /**
    * The child data classes under this Data Class.
    */
-  dataClasses?: DataClassHierarchy[];
+  dataClasses?: DataClassNode[];
 
   /**
    * The Data Elements under this Data Class.
@@ -61,4 +61,4 @@ export interface DataClassHierarchy {
 
 export type DataClassFull =
   DataClassDetail
-  & DataClassHierarchy;
+  & DataClassNode;

--- a/src/mdm-data-class.model.ts
+++ b/src/mdm-data-class.model.ts
@@ -59,6 +59,6 @@ export interface DataClassHierarchy {
   dataElements?: DataElementDetail[];
 }
 
-export type DataClassFull = 
-  DataClassDetail 
+export type DataClassFull =
+  DataClassDetail
   & DataClassHierarchy;

--- a/src/mdm-data-class.model.ts
+++ b/src/mdm-data-class.model.ts
@@ -19,6 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { Historical, Securable } from './mdm-model-types.model';
 import { Breadcrumb, CatalogueItemDomainType, MdmIndexResponse, MdmResponse, PageParameters, QueryParameters, SortParameters, Uuid } from './mdm-common.model';
+import { DataElementDetail } from './mdm-data-element.model';
 
 export type DataClassIndexParameters = SortParameters & PageParameters & QueryParameters;
 
@@ -42,3 +43,22 @@ export type DataClassDetail =
 
 export type DataClassIndexResponse = MdmIndexResponse<DataClass>;
 export type DataClassDetailResponse = MdmResponse<DataClassDetail>;
+
+/**
+ * Represents hierarchy information for a Data Class.
+ */
+export interface DataClassHierarchy {
+  /**
+   * The child data classes under this Data Class.
+   */
+  dataClasses?: DataClassHierarchy[];
+
+  /**
+   * The Data Elements under this Data Class.
+   */
+  dataElements?: DataElementDetail[];
+}
+
+export type DataClassFull = 
+  DataClassDetail 
+  & DataClassHierarchy;

--- a/src/mdm-data-model.model.ts
+++ b/src/mdm-data-model.model.ts
@@ -97,8 +97,8 @@ export interface DataModelHierarchy {
   childDataClasses?: DataClassFull[];
 }
 
-export type DataModelFull = 
-  DataModelDetail 
+export type DataModelFull =
+  DataModelDetail
   & DataModelHierarchy;
 
 export type DataModelFullResponse = MdmResponse<DataModelFull>;

--- a/src/mdm-data-model.model.ts
+++ b/src/mdm-data-model.model.ts
@@ -83,9 +83,9 @@ export interface DataModelIntersection {
 export type DataModelIntersectionResponse = MdmResponse<DataModelIntersection>;
 
 /**
- * Represents hierarchy information for a Data Model.
+ * Represents information for a Data Model relating to a hierarchy.
  */
-export interface DataModelHierarchy {
+export interface DataModelNode {
   /**
    * The data types available for this Data Model.
    */
@@ -99,6 +99,6 @@ export interface DataModelHierarchy {
 
 export type DataModelFull =
   DataModelDetail
-  & DataModelHierarchy;
+  & DataModelNode;
 
 export type DataModelFullResponse = MdmResponse<DataModelFull>;

--- a/src/mdm-data-model.model.ts
+++ b/src/mdm-data-model.model.ts
@@ -19,7 +19,8 @@ SPDX-License-Identifier: Apache-2.0
 
 import { Branchable, Finalisable, Historical, Modelable, ModelableDetail, ModelCreatePayload, SecurableModel, Versionable } from './mdm-model-types.model';
 import { MdmIndexResponse, MdmResponse, Payload, QueryParameters, Uuid } from './mdm-common.model';
-import { DataTypeProvider } from './mdm-data-type.model';
+import { DataTypeDetail, DataTypeProvider } from './mdm-data-type.model';
+import { DataClassFull } from './mdm-data-class.model';
 
 export type DataModelType = 'Data Standard' | 'Data Asset';
 
@@ -80,3 +81,24 @@ export interface DataModelIntersection {
 }
 
 export type DataModelIntersectionResponse = MdmResponse<DataModelIntersection>;
+
+/**
+ * Represents hierarchy information for a Data Model.
+ */
+export interface DataModelHierarchy {
+  /**
+   * The data types available for this Data Model.
+   */
+  dataTypes?: DataTypeDetail[];
+
+  /**
+   * Gets all child Data Classes for this Data Model.
+   */
+  childDataClasses?: DataClassFull[];
+}
+
+export type DataModelFull = 
+  DataModelDetail 
+  & DataModelHierarchy;
+
+export type DataModelFullResponse = MdmResponse<DataModelFull>;

--- a/src/mdm-data-model.resource.ts
+++ b/src/mdm-data-model.resource.ts
@@ -280,12 +280,13 @@ export class MdmDataModelResource extends MdmResource {
 
   /**
    * Gets the hierarchical information for a Data Model, returning all child classes, elements and types.
+   *
    * @param id The unique identifier of the data model to get.
    * @param query Optional query parameters, if required.
    * @param options Optional REST handler parameters, if required.
    * @returns The result of the `GET` request.
    *
-   * `200 OK` - will return a {@link DataModelFullResponse} containing a single {@link DataModelFull} object, 
+   * `200 OK` - will return a {@link DataModelFullResponse} containing a single {@link DataModelFull} object,
    * including all details of the Data Model/Type/Class/Element hierarchy.
    */
   hierarchy(id: Uuid, query?: QueryParameters, options?: RequestSettings) {

--- a/src/mdm-data-model.resource.ts
+++ b/src/mdm-data-model.resource.ts
@@ -278,9 +278,19 @@ export class MdmDataModelResource extends MdmResource {
     return this.simplePost(url, query, options);
   }
 
-  hierarchy(dataModelId: string, queryStringParams?: QueryParameters, restHandlerOptions?: RequestSettings) {
-    const url = `${this.apiEndpoint}/dataModels/${dataModelId}/hierarchy`;
-    return this.simpleGet(url, queryStringParams, restHandlerOptions);
+  /**
+   * Gets the hierarchical information for a Data Model, returning all child classes, elements and types.
+   * @param id The unique identifier of the data model to get.
+   * @param query Optional query parameters, if required.
+   * @param options Optional REST handler parameters, if required.
+   * @returns The result of the `GET` request.
+   *
+   * `200 OK` - will return a {@link DataModelFullResponse} containing a single {@link DataModelFull} object, 
+   * including all details of the Data Model/Type/Class/Element hierarchy.
+   */
+  hierarchy(id: Uuid, query?: QueryParameters, options?: RequestSettings) {
+    const url = `${this.apiEndpoint}/dataModels/${id}/hierarchy`;
+    return this.simpleGet(url, query, options);
   }
 
   newModelVersion(dataModelId: string, data: any, restHandlerOptions?: RequestSettings) {

--- a/src/mdm-model-types.model.ts
+++ b/src/mdm-model-types.model.ts
@@ -135,6 +135,12 @@ export interface Modelable extends CatalogueItem {
   label: string;
   description?: string;
   deleted?: boolean;
+
+  /**
+   * If this model is finalised, this represents the version number of this model. If not finalised,
+   * this is not defined.
+   */
+  modelVersion?: Version;
 }
 
 export interface ModelableDetail {


### PR DESCRIPTION
New updated type definitions for Data Models required for `mdm-research-browser`:

* Define the Data Model `hierarchy` endpoint
* Update `SearchQueryParameter` type