### PR TITLE
Feature/mc 9812 Update endpoints for profile search

### DIFF
--- a/src/mdm-common.model.ts
+++ b/src/mdm-common.model.ts
@@ -425,7 +425,7 @@ export interface CatalogueItemReference {
 export interface SearchQueryParameters extends SortParameters, PageParameters, QueryParameters {
   /**
    * The term(s) to search for in the catalogue.
-   * 
+   *
    * You can supply the search term "*" to return all catalogue items under a catalogue or parent catalogue item.
    */
   searchTerm?: string;

--- a/src/mdm-common.model.ts
+++ b/src/mdm-common.model.ts
@@ -425,6 +425,8 @@ export interface CatalogueItemReference {
 export interface SearchQueryParameters extends SortParameters, PageParameters, QueryParameters {
   /**
    * The term(s) to search for in the catalogue.
+   * 
+   * You can supply the search term "*" to return all catalogue items under a catalogue or parent catalogue item.
    */
   searchTerm?: string;
 

--- a/src/mdm-profile.model.ts
+++ b/src/mdm-profile.model.ts
@@ -17,7 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 
-import { CatalogueItemDomainType, MdmIndexResponse, MdmResponse, Payload, Uuid, Version } from './mdm-common.model';
+import { Breadcrumb, CatalogueItemDomainType, MdmIndexResponse, MdmResponse, Payload, Uuid, Version } from './mdm-common.model';
 
 export type ProfileFieldDataType =
   'boolean'
@@ -138,3 +138,23 @@ export interface Metadata {
 export type MetadataIndexResponse = MdmIndexResponse<Metadata>;
 
 export type ProfilePayload = Profile & Payload;
+
+export interface ProfileSearchResultField {
+  [key: string]: any;
+  fieldName: string;
+  metadataPropertyName: string;
+  currentValue?: string;
+  dataType: ProfileFieldDataType;
+  allowedValues?: string[];
+}
+
+export interface ProfileSearchResult {
+  [key: string]: any;
+  id: Uuid;
+  label: string;
+  description?: string;
+  breadcrumbs: Breadcrumb[];
+  profileFields: ProfileSearchResultField[];
+}
+
+export type ProfileSearchResponse = MdmIndexResponse<ProfileSearchResult>;

--- a/src/mdm-profile.model.ts
+++ b/src/mdm-profile.model.ts
@@ -79,6 +79,13 @@ export interface Profile {
 
 export type ProfileResponse = MdmResponse<Profile>;
 
+export interface ProfileDefinition {
+  [key: string]: any;
+  sections: ProfileSection[];
+}
+
+export type ProfileDefinitionResponse = MdmResponse<ProfileDefinition>;
+
 export interface ProfileProvider {
   name: string;
   namespace: string;

--- a/src/mdm-profile.resource.ts
+++ b/src/mdm-profile.resource.ts
@@ -276,7 +276,7 @@ export class MdmProfileResource extends MdmResource {
   }
 
   /**
-   * `HTTP POST` - Search within the catalogue for one or more search terms and return profile fields matching 
+   * `HTTP POST` - Search within the catalogue for one or more search terms and return profile fields matching
    * the provided profile.
    *
    * @param profileNamespace The namespace of the profile to validate.
@@ -298,7 +298,7 @@ export class MdmProfileResource extends MdmResource {
   }
 
   /**
-   * `HTTP POST` - Search within a single catalogue item for one or more search terms and return profile fields matching 
+   * `HTTP POST` - Search within a single catalogue item for one or more search terms and return profile fields matching
    * the provided profile.
    *
    * @param domainType The domain type of the catalogue item to search in.

--- a/src/mdm-profile.resource.ts
+++ b/src/mdm-profile.resource.ts
@@ -121,6 +121,27 @@ export class MdmProfileResource extends MdmResource {
   }
 
   /**
+   * `HTTP GET` - Gets a profile definition for a namespace/name. This is similar to a full profile but
+   * without any assigned values or mapped to a catalogue item.
+   *
+   * @param profileNamespace The namespace of the profile to get.
+   * @param profileName The name of the profile to get.
+   * @param query Optional query string parameters, if required.
+   * @param options Optional REST handler options, if required.
+   * @returns The result of the `GET` request.
+   *
+   * `200 OK` - will return a {@link ProfileDefinitionResponse} containing a {@link ProfileDefinition}.
+   */
+  definition(    
+    profileNamespace: string,
+    profileName: string,
+    query?: QueryParameters,
+    options?: RequestSettings) {
+    const url = `${this.apiEndpoint}/profiles/${profileNamespace}/${profileName}`;    
+    return this.simpleGet(url, query, options);
+  }
+
+  /**
    * `HTTP POST` - Saves a profile and its metadata values to a catalogue item.
    *
    * @param domainType The domain type of the catalogue item to get.

--- a/src/mdm-profile.resource.ts
+++ b/src/mdm-profile.resource.ts
@@ -17,7 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 import { Profile, ProfileContextIndexPayload, ProfileContextPayload } from './mdm-profile.model';
-import { RequestSettings, QueryParameters, Uuid, Version, MultiFacetAwareDomainType, CatalogueItemDomainType, getMultiFacetAwareDomainType } from './mdm-common.model';
+import { RequestSettings, QueryParameters, Uuid, Version, MultiFacetAwareDomainType, CatalogueItemDomainType, getMultiFacetAwareDomainType, SearchQueryParameters } from './mdm-common.model';
 import { MdmResource } from './mdm-resource';
 
 /**
@@ -273,5 +273,53 @@ export class MdmProfileResource extends MdmResource {
     options?: RequestSettings) {
     const url = `${this.apiEndpoint}/${getMultiFacetAwareDomainType(domainType)}/${catalogueItemId}/profile/validateMany`;
     return this.simplePost(url, payload, options);
+  }
+
+  /**
+   * `HTTP POST` - Search within the catalogue for one or more search terms and return profile fields matching 
+   * the provided profile.
+   *
+   * @param profileNamespace The namespace of the profile to validate.
+   * @param profileName The name of the profile to validate.
+   * @param query The query parameters to control the search.
+   * @param options Optional REST handler parameters, if required.
+   * @returns The result of the `POST` request.
+   *
+   * `200 OK` - will return a {@link ProfileSearchResponse} containing a collection of
+   * {@link ProfileSearchResult} objects.
+   */
+  search(
+    profileNamespace: string,
+    profileName: string,
+    query: SearchQueryParameters,
+    options?: RequestSettings) {
+    const url = `${this.apiEndpoint}/profiles/${profileNamespace}/${profileName}/search`;
+    return this.simplePost(url, query, options);
+  }
+
+  /**
+   * `HTTP POST` - Search within a single catalogue item for one or more search terms and return profile fields matching 
+   * the provided profile.
+   *
+   * @param domainType The domain type of the catalogue item to search in.
+   * @param id The unique identifier of the catalogue item to search in.
+   * @param profileNamespace The namespace of the profile to validate.
+   * @param profileName The name of the profile to validate.
+   * @param query The query parameters to control the search.
+   * @param options Optional REST handler parameters, if required.
+   * @returns The result of the `POST` request.
+   *
+   * `200 OK` - will return a {@link ProfileSearchResponse} containing a collection of
+   * {@link ProfileSearchResult} objects.
+   */
+  searchCatalogueItem(
+    domainType: MultiFacetAwareDomainType,
+    id: Uuid,
+    profileNamespace: string,
+    profileName: string,
+    query: SearchQueryParameters,
+    options?: RequestSettings) {
+    const url = `${this.apiEndpoint}/${getMultiFacetAwareDomainType(domainType)}/${id}/profiles/${profileNamespace}/${profileName}/search`;
+    return this.simplePost(url, query, options);
   }
 }

--- a/src/mdm-profile.resource.ts
+++ b/src/mdm-profile.resource.ts
@@ -132,12 +132,12 @@ export class MdmProfileResource extends MdmResource {
    *
    * `200 OK` - will return a {@link ProfileDefinitionResponse} containing a {@link ProfileDefinition}.
    */
-  definition(    
+  definition(
     profileNamespace: string,
     profileName: string,
     query?: QueryParameters,
     options?: RequestSettings) {
-    const url = `${this.apiEndpoint}/profiles/${profileNamespace}/${profileName}`;    
+    const url = `${this.apiEndpoint}/profiles/${profileNamespace}/${profileName}`;
     return this.simpleGet(url, query, options);
   }
 


### PR DESCRIPTION
Add endpoints to support searching with profiles:

1. Search entire catalogue and return a given profile field set
2. Search within a particular catalogue item and return a given profile field set
3. Get definition of a profile without requiring a catalogue item