### PR TITLE
MC-9891 Updates to SubscribedCatalogueResource and types

### DIFF
--- a/src/core/mdm-import-export.model.ts
+++ b/src/core/mdm-import-export.model.ts
@@ -44,6 +44,12 @@ export interface Importer {
   knownMetadataKeys: any[];
 }
 
+export interface ImporterProvider {
+  name: string;
+  namespace: string;
+  version?: Version;
+}
+
 export type ImporterParameterType =
   | 'Integer'
   | 'String'

--- a/src/federation/mdm-subscribed-catalogues.model.ts
+++ b/src/federation/mdm-subscribed-catalogues.model.ts
@@ -16,6 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
+import { ImporterProvider } from '../core';
 import {
   CatalogueItemDomainType,
   MdmIndexResponse,
@@ -24,6 +25,8 @@ import {
   Uuid
 } from '../mdm-common.model';
 
+export type SubscribedCatalogueTypeResponse = MdmResponse<string[]>;
+
 export interface SubscribedCatalogue {
   id?: Uuid;
   url: string;
@@ -31,6 +34,7 @@ export interface SubscribedCatalogue {
   label: string;
   description?: string;
   refreshPeriod?: number;
+  subscribedCatalogueType: string;
 }
 
 export type SubscribedCatalogueResponse = MdmResponse<SubscribedCatalogue>;
@@ -38,32 +42,60 @@ export type SubscribedCatalogueIndexResponse = MdmIndexResponse<
   SubscribedCatalogue
 >;
 
-export interface AvailableDataModel {
-  modelId?: Uuid;
-  label: string;
-  description?: string;
-  modelType: CatalogueItemDomainType;
-  version?: string;
+export interface PublishedDataModelLink {
+  contentType: string;
+  url: string;
 }
 
 export interface PublishedDataModel {
   modelId?: Uuid;
   label: string;
   description?: string;
-  modelType: CatalogueItemDomainType;
+  modelType?: CatalogueItemDomainType;
   version?: string;
+  dateCreated?: string;
+  datePublished?: string;
+  lastUpdated?: string;
+  links?: PublishedDataModelLink[];
 }
 
-export interface SubscribedDataModel extends Payload {
-  id?: Uuid;
+export interface SubscribedDataModel {
+  id: Uuid;
+  subscribedModelId: Uuid;
+  folderId: Uuid;
+  federated: boolean;
+  localModelId?: Uuid;
+}
+
+export interface CreateSubscribedDataModel {
   subscribedModelId: Uuid;
   subscribedModelType: CatalogueItemDomainType;
   folderId: Uuid;
 }
 
-export type AvailableDataModelIndexResponse = MdmIndexResponse<
-  AvailableDataModel
->;
+export interface SubscribedDataModelPayload extends Payload {
+  /**
+   * The details of the published model to subscribe to.
+   */
+  subscribedModel: CreateSubscribedDataModel;
+
+  /**
+   * Optional content URL to fetch the published model from.
+   */
+  url?: string;
+
+  /**
+   * Optional content type when using the URL.
+   */
+  contentType?: string;
+
+  /**
+   * Optional importer service to use for the subscription. This is not required, but can be used to
+   * override the subscription process.
+   */
+  importerProviderService?: ImporterProvider;
+}
+
 export type PublishedDataModelIndexResponse = MdmIndexResponse<
   PublishedDataModel
 >;

--- a/src/federation/mdm-subscribed-catalogues.resource.ts
+++ b/src/federation/mdm-subscribed-catalogues.resource.ts
@@ -18,7 +18,6 @@ SPDX-License-Identifier: Apache-2.0
 */
 import {
   SubscribedCatalogue,
-  SubscribedDataModel,
   SubscribedDataModelPayload
 } from './mdm-subscribed-catalogues.model';
 import { RequestSettings, QueryParameters, Uuid } from '../mdm-common.model';

--- a/src/federation/mdm-subscribed-catalogues.resource.ts
+++ b/src/federation/mdm-subscribed-catalogues.resource.ts
@@ -18,42 +18,28 @@ SPDX-License-Identifier: Apache-2.0
 */
 import {
   SubscribedCatalogue,
-  SubscribedDataModel
+  SubscribedDataModel,
+  SubscribedDataModelPayload
 } from './mdm-subscribed-catalogues.model';
 import { RequestSettings, QueryParameters, Uuid } from '../mdm-common.model';
-import { MdmResource } from '../mdm-resource';
+import { MdmCommonDomainResource } from '../mdm-common.resource';
+import { MdmResourcesConfiguration, MdmRestHandler } from '../mdm-resource';
 
 /**
  * MDM resource for managing subscribed catalogues and federated models.
  */
-export class MdmSubscribedCataloguesResource extends MdmResource {
+export class MdmSubscribedCataloguesResource extends MdmCommonDomainResource {
   /**
-   * `HTTP GET` - Gets a Subscribed Catalogue by ID.
+   * Constructs a new `MdmSubscribedCataloguesResource`.
    *
-   * @param id The unique identifier of the Subscribed Catalogue to get.
-   * @param query Optional query string parameters for the GET request.
-   * @param options Optional REST handler parameters.
-   * @returns The result of the `GET` request.
-   *
-   * `200 OK` - will return a {@link SubscribedCatalogueResponse} containing a {@link SubscribedCatalogue}.
+   * @param config Optionally provide configuration options to this resource class. If not provided, suitable defaults will be used.
+   * @param restHandler Optionally provide a specific {@link MdmRestHandler}. If not provided, the {@link DefaultMdmRestHandler} implementation will be used.
    */
-  get(id: Uuid, query?: QueryParameters, options?: RequestSettings) {
-    const url = `${this.apiEndpoint}/subscribedCatalogues/${id}`;
-    return this.simpleGet(url, query, options);
-  }
-
-  /**
-   * `HTTP GET` - Gets a list of all Subscribed Catalogues.
-   *
-   * @param query Optional query string parameters for the GET request.
-   * @param options Optional REST handler parameters.
-   * @returns The result of the `GET` request.
-   *
-   * `200 OK` - will return a {@link SubscribedCatalogueIndexResponse} containing a list of {@link SubscribedCatalogue} items.
-   */
-  list(query?: QueryParameters, options?: RequestSettings) {
-    const url = `${this.apiEndpoint}/subscribedCatalogues`;
-    return this.simpleGet(url, query, options);
+  constructor(
+    config?: MdmResourcesConfiguration,
+    restHandler?: MdmRestHandler
+  ) {
+    super('subscribedCatalogues', config, restHandler);
   }
 
   /**
@@ -86,37 +72,16 @@ export class MdmSubscribedCataloguesResource extends MdmResource {
   }
 
   /**
-   * `HTTP DELETE` - Removes an existing Subscribed Catalogue.
+   * `HTTP GET` - Gets a list of all available connection types supported by Subscribed Catalogues.
    *
-   * @param id The unique identifier of the Subscribed Catalogue to remove.
-   * @param query Optional query string parameters for the GET request.
-   * @param options Optional REST handler parameters.
-   * @returns The result of the `DELETE` request.
-   *
-   * On success, the response will be a `204 No Content` and the response body will be empty.
-   */
-  remove(id: Uuid, query?: QueryParameters, options?: RequestSettings) {
-    const url = `${this.apiEndpoint}/subscribedCatalogues/${id}`;
-    return this.simpleDelete(url, query, options);
-  }
-
-  /**
-   * `HTTP GET` - Gets a list of all available federated models from a Subscribed Catalogue.
-   *
-   * @param id The UUID of the Subscribed Catalogue to search in.
    * @param query Optional query string parameters for the GET request.
    * @param options Optional REST handler parameters.
    * @returns The result of the `GET` request.
-   * @deprecated use listPublishedModels
    *
-   * `200 OK` - will return a {@link AvailableDataModelIndexResponse} containing a list of {@link AvailableDataModel} items.
+   * `200 OK` - will return a {@link SubscribedCatalogueTypeResponse} containing a list of connnection type names.
    */
-  listAvailableModels(
-    id: Uuid,
-    query?: QueryParameters,
-    options?: RequestSettings
-  ) {
-    const url = `${this.apiEndpoint}/subscribedCatalogues/${id}/availableModels`;
+  types(query?: QueryParameters, options?: RequestSettings) {
+    const url = `${this.apiEndpoint}/${this.domain}/types`;
     return this.simpleGet(url, query, options);
   }
 
@@ -198,7 +163,7 @@ export class MdmSubscribedCataloguesResource extends MdmResource {
    * `HTTP POST` - Creates a new subscription to a model in a Subscribed Catalogue.
    *
    * @param catalogueId The UUID of the Subscribed Catalogue to save to.
-   * @param data The data to use for creation.
+   * @param payload The data to use for creation.
    * @param options Optional REST handler parameters.
    * @returns The result of the `POST` request.
    *
@@ -206,11 +171,11 @@ export class MdmSubscribedCataloguesResource extends MdmResource {
    */
   saveSubscribedModel(
     catalogueId: Uuid,
-    data: SubscribedDataModel,
+    payload: SubscribedDataModelPayload,
     options?: RequestSettings
   ) {
     const url = `${this.apiEndpoint}/subscribedCatalogues/${catalogueId}/subscribedModels`;
-    return this.simplePost(url, data, options);
+    return this.simplePost(url, payload, options);
   }
 
   /**


### PR DESCRIPTION
* Inherit from MdmCommonDomainResource
* Add types endpoint to get possible connection types
* Make PublishedDataModel.modelType optional
* Remove AvailableDataModel - obsolete
* Update PublishedDataModel with content links and dates
* Adjust subscribed catalogue creation - use correct structure for payload, add additional optional properties