### PR TITLE
Add support for Reference Data Type domain

### DIFF
--- a/src/mdm-common.model.ts
+++ b/src/mdm-common.model.ts
@@ -80,7 +80,9 @@ export enum CatalogueItemDomainType {
   ExternalCatalogues = 'ExternalCatalogues',
   SubscribedCatalogue = 'SubscribedCatalogue',
   FederatedDataModel = 'FederatedDataModel',
-  TermRelationshipType = 'TermRelationshipType'
+  TermRelationshipType = 'TermRelationshipType',
+  ReferencePrimitiveType = 'ReferencePrimitiveType',
+  ReferenceEnumerationType = 'ReferenceEnumerationType'
 }
 
 /**

--- a/src/mdm-model-child.resource.ts
+++ b/src/mdm-model-child.resource.ts
@@ -1,0 +1,168 @@
+/*
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import {
+  FilterQueryParameters,
+  QueryParameters,
+  RequestSettings,
+  Uuid
+} from './mdm-common.model';
+import { ModelChildCreatePayload, ModelDomain } from './mdm-model-types.model';
+import {
+  MdmResource,
+  MdmResourcesConfiguration,
+  MdmRestHandler
+} from './mdm-resource';
+
+/**
+ * Base class representing all the operations that a typical child domain of a model can perform.
+ *
+ * Model domain types allowed are defined by the {@link ModelDomain} type.
+ *
+ * Child domains refer to elements within the model domain e.g. data types for data models.
+ */
+export class MdmModelChildDomainResource extends MdmResource {
+  /**
+   * Constructs a new `MdmCommonDomainResource`.
+   *
+   * @param modelDomain The domain type for the model operations - the parent domain of the children. This must be the pluralised form of the domain
+   * name e.g. 'dataModels', etc.
+   * @param domain The domain type for the child operations. This must be the pluralised form of the domain name e.g. 'dataTypes', 'dataElements', etc.
+   * @param config Optionally provide configuration options to this resource class. If not provided, suitable defaults will be used.
+   * @param restHandler Optionally provide a specific {@link MdmRestHandler}. If not provided, the {@link DefaultMdmRestHandler} implementation will be used.
+   */
+  constructor(
+    protected modelDomain: ModelDomain,
+    protected domain: string,
+    config?: MdmResourcesConfiguration,
+    restHandler?: MdmRestHandler
+  ) {
+    super(config, restHandler);
+  }
+
+  /**
+   * `HTTP GET` - Request the list of child items for a model.
+   *
+   * @param modelId The unique identifier of the parent model.
+   * @param query Optional query string parameters to filter the returned list, if required.
+   * @param options Optional REST handler parameters, if required.
+   * @returns The result of the `GET` request.
+   *
+   * `200 OK` - will return a {@link MdmIndexResponse} containing a list of items. The items will be representative
+   * of the type of {@link domain} they are for.
+   *
+   * @see {@link MdmModelChildResource.get}
+   */
+  list(
+    modelId: Uuid,
+    query?: FilterQueryParameters,
+    options?: RequestSettings
+  ) {
+    const url = `${this.apiEndpoint}/${this.modelDomain}/${modelId}/${this.domain}`;
+    return this.simpleGet(url, query, options);
+  }
+
+  /**
+   * `HTTP GET` - Request a child item from a model.
+   *
+   * @param modelId The unique identifier of the parent model.
+   * @param id A unique identifier of the item to fetch.
+   * @param query Optional query parameters, if required.
+   * @param options Optional REST handler parameters, if required.
+   * @returns The result of the `GET` request.
+   *
+   * `200 OK` - will return a {@link MdmResponse} containing an item in the body. The item will be representative
+   * of the type of {@link domain} it is for.
+   */
+  get(
+    modelId: Uuid,
+    id: string,
+    query?: QueryParameters,
+    options?: RequestSettings
+  ) {
+    const url = `${this.apiEndpoint}/${this.modelDomain}/${modelId}/${this.domain}/${id}`;
+    return this.simpleGet(url, query, options);
+  }
+
+  /**
+   * `HTTP POST` - Creates a new item under a chosen model.
+   *
+   * @param modelId The unique identifier of the parent model.
+   * @param data The payload of the request containing all the details to create.
+   * @param query Optional query parameters to control the creation of the item, if required.
+   * @param options Optional REST handler parameters, if required.
+   * @returns The result of the `POST` request.
+   *
+   * `200 OK` - will return a {@link MdmResponse} containing an item in the body. The item will be representative
+   * of the type of {@link domain} it is for.
+   */
+  create<P extends ModelChildCreatePayload, Q extends QueryParameters>(
+    modelId: Uuid,
+    data: P,
+    query?: Q,
+    options?: RequestSettings
+  ) {
+    const queryString = this.generateQueryString(query);
+    const url = `${this.apiEndpoint}/${this.modelDomain}/${modelId}/${
+      this.domain
+    }${queryString && queryString.length > 0 ? queryString : ''}`;
+    return this.simplePost(url, data, options);
+  }
+
+  /**
+   * `HTTP PUT` - Updates an existing model item.
+   *
+   * @param modelId The unique identifier of the parent model.
+   * @param id The unique identifier of the item to update.
+   * @param data The payload of the request containing all the details to update.
+   * @param options Optional REST handler parameters, if required.
+   * @returns The result of the `POST` request.
+   *
+   * `200 OK` - will return a {@link MdmResponse} containing an item in the body. The item will be representative
+   * of the type of {@link domain} it is for.
+   */
+  update<P extends ModelChildCreatePayload>(
+    modelId: Uuid,
+    id: Uuid,
+    data: P,
+    options?: RequestSettings
+  ) {
+    const url = `${this.apiEndpoint}/${this.modelDomain}/${modelId}/${this.domain}/${id}`;
+    return this.simplePut(url, data, options);
+  }
+
+  /**
+   * `HTTP DELETE` - Removes an existing item from a model.
+   *
+   * @param id The unique identifier of the item to remove.
+   * @param query Optional query parameters to control the deletion of the item, if required.
+   * @param options Optional REST handler options, if required.
+   * @returns The result of the `DELETE` request.
+   *
+   * On success, the response will be a `204 No Content` and the response body will be empty.
+   */
+  remove(
+    modelId: Uuid,
+    id: string,
+    query?: QueryParameters,
+    options?: RequestSettings
+  ) {
+    const url = `${this.apiEndpoint}/${this.modelDomain}/${modelId}/${this.domain}/${id}`;
+    return this.simpleDelete(url, query, options);
+  }
+}

--- a/src/mdm-model-types.model.ts
+++ b/src/mdm-model-types.model.ts
@@ -179,6 +179,13 @@ export type ModelDomainDetail = Modelable &
 
 export type ModelDomainDetailResponse = MdmResponse<ModelDomainDetail>;
 
+export interface ModelChildItem {
+  /**
+   * The unique identifier of the parent/owner model.
+   */
+  model?: Uuid;
+}
+
 /**
  * Payload for endpoints that finalise a model type.
  */
@@ -210,6 +217,11 @@ export interface ModelCreatePayload extends Payload {
   classifiers?: CatalogueItemReference[];
 }
 
+export interface ModelChildCreatePayload extends Payload {
+  label: string;
+  description?: string;
+}
+
 export interface ModelUpdatePayload extends Payload {
   id: Uuid;
   domainType: CatalogueItemDomainType;
@@ -219,6 +231,12 @@ export interface ModelUpdatePayload extends Payload {
   description?: string;
   aliases?: string[];
   classifiers?: Classifier[];
+}
+
+export interface ModelChildUpdatePayload extends Payload {
+  id: Uuid;
+  label: string;
+  description?: string;
 }
 
 /**

--- a/src/reference-data/index.ts
+++ b/src/reference-data/index.ts
@@ -19,5 +19,6 @@ SPDX-License-Identifier: Apache-2.0
 export * from './mdm-reference-data-element.resource';
 export * from './mdm-reference-data-model.model';
 export * from './mdm-reference-data-model.resource';
+export * from './mdm-reference-data-type.model';
 export * from './mdm-reference-data-type.resource';
 export * from './mdm-reference-data-value.resource';

--- a/src/reference-data/mdm-reference-data-type.model.ts
+++ b/src/reference-data/mdm-reference-data-type.model.ts
@@ -1,0 +1,77 @@
+/*
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import {
+  CatalogueItemDetail,
+  CatalogueItemDomainType,
+  MdmIndexResponse,
+  MdmResponse,
+  Uuid
+} from '../mdm-common.model';
+import {
+  Historical,
+  ModelChildCreatePayload,
+  ModelChildItem,
+  Securable
+} from '../mdm-model-types.model';
+
+export interface ReferenceDataEnumerationValue {
+  id: Uuid;
+  index: number;
+  key: string;
+  value: string;
+  category?: string;
+}
+
+export interface ReferenceDataType extends CatalogueItemDetail, ModelChildItem {
+  referenceEnumerationValues?: ReferenceDataEnumerationValue[];
+}
+
+export type ReferenceDataTypeDetail = ReferenceDataType &
+  Securable &
+  Historical;
+
+export type ReferenceDataTypeIndexResponse = MdmIndexResponse<
+  ReferenceDataType
+>;
+export type ReferenceDataTypeDetailResponse = MdmResponse<
+  ReferenceDataTypeDetail
+>;
+
+export interface ReferenceDataEnumerationValueCreatePayload {
+  key: string;
+  value: string;
+  category?: string;
+}
+
+/**
+ * Payload for creating a new Reference Data Type.
+ *
+ * For primitives, just set the `domainType` to `ReferencePrimitiveType` and provide the other required fields
+ * e.g. label.
+ *
+ * For enumeration types, also pass an array of {@link ReferenceDataEnumerationValueCreatePayload} objects to
+ * define the enumeration values.
+ */
+export interface ReferenceDataTypeCreatePayload
+  extends ModelChildCreatePayload {
+  domainType:
+    | CatalogueItemDomainType.ReferencePrimitiveType
+    | CatalogueItemDomainType.ReferenceEnumerationType;
+  referenceEnumerationValues?: ReferenceDataEnumerationValueCreatePayload[];
+}

--- a/src/reference-data/mdm-reference-data-type.resource.ts
+++ b/src/reference-data/mdm-reference-data-type.resource.ts
@@ -16,63 +16,44 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { RequestSettings, QueryParameters } from '../mdm-common.model';
-import { MdmResource } from '../mdm-resource';
+import { MdmModelChildDomainResource } from '../mdm-model-child.resource';
+import { RequestSettings, Uuid } from '../mdm-common.model';
+import { MdmResourcesConfiguration, MdmRestHandler } from '../mdm-resource';
 
 /**
- * Controller: referenceDataModel
- |   GET    | /api/referenceDataModels/${referenceDataModelId}/referenceDataTypes                                                                        | Action: index
- |   GET    | /api/referenceDataModels/${referenceDataModelId}/referenceDataTypes/${referenceDataTypeId}                                                 | Action: get
- |   POST   | /api/referenceDataModels/${referenceDataModelId}/referenceDataTypes                                                                        | Action: save
- |   PUT    | /api/referenceDataModels/${referenceDataModelId}/referenceDataTypes/${referenceDataTypeId}                                                 | Action: update
- |   DELETE | /api/referenceDataModels/${referenceDataModelId}/referenceDataTypes/${referenceDataTypeId}                                                 | Action: delete
+ * Resource for managing Reference Data Types.
+ *
+ * All responses will return either {@link ReferenceDataType} (for lists) or
+ * {@link ReferenceDataTypeDetail} (for individual operations).
  */
-export class MdmReferenceDataTypeResource extends MdmResource {
-  list(
-    referenceDataModelId: string,
-    queryStringParams?: QueryParameters,
-    restHandlerOptions?: RequestSettings
+export class MdmReferenceDataTypeResource extends MdmModelChildDomainResource {
+  constructor(
+    config?: MdmResourcesConfiguration,
+    restHandler?: MdmRestHandler
   ) {
-    const url = `${this.apiEndpoint}/referenceDataModels/${referenceDataModelId}/referenceDataTypes`;
-    return this.simpleGet(url, queryStringParams, restHandlerOptions);
+    super('referenceDataModels', 'referenceDataTypes', config, restHandler);
   }
 
-  get(
-    referenceDataModelId: string,
-    referenceDataTypeId: string,
-    queryStringParams?: QueryParameters,
-    restHandlerOptions?: RequestSettings
+  /**
+   * `HTTP POST` - Copies an existing Reference Data Type from one Reference Data Model to another target
+   * Reference Data Model.
+   *
+   * @param targetModelId The unique indentifier of the target model to copy to.
+   * @param sourceModelId The unique identifier of the source model.
+   * @param sourceTypeId The unique identifier of the data type to copy.
+   * @param options Optional REST handler parameters, if required.
+   * @returns The result of the `POST` request.
+   *
+   * `200 OK` - will return a {@link ReferenceDataTypeDetailResponse} containing the new copy of a
+   * {@link ReferenceDataTypeDetail} object.
+   */
+  copy(
+    targetModelId: Uuid,
+    sourceModelId: Uuid,
+    sourceTypeId: Uuid,
+    options?: RequestSettings
   ) {
-    const url = `${this.apiEndpoint}/referenceDataModels/${referenceDataModelId}/referenceDataTypes/${referenceDataTypeId}`;
-    return this.simpleGet(url, queryStringParams, restHandlerOptions);
-  }
-
-  save(
-    referenceDataModelId: string,
-    data: any,
-    restHandlerOptions?: RequestSettings
-  ) {
-    const url = `${this.apiEndpoint}/referenceDataModels/${referenceDataModelId}/referenceDataTypes`;
-    return this.simplePost(url, data, restHandlerOptions);
-  }
-
-  update(
-    referenceDataModelId: string,
-    referenceDataTypeId: string,
-    data: any,
-    restHandlerOptions?: RequestSettings
-  ) {
-    const url = `${this.apiEndpoint}/referenceDataModels/${referenceDataModelId}/referenceDataTypes/${referenceDataTypeId}`;
-    return this.simplePut(url, data, restHandlerOptions);
-  }
-
-  remove(
-    referenceDataModelId: string,
-    referenceDataTypeId: string,
-    queryStringParams?: QueryParameters,
-    restHandlerOptions?: RequestSettings
-  ) {
-    const url = `${this.apiEndpoint}/referenceDataModels/${referenceDataModelId}/referenceDataTypes/${referenceDataTypeId}`;
-    return this.simpleDelete(url, queryStringParams, restHandlerOptions);
+    const url = `${this.apiEndpoint}/${this.modelDomain}/${targetModelId}/${this.domain}/${sourceModelId}/${sourceTypeId}`;
+    return this.simplePost(url, {}, options);
   }
 }


### PR DESCRIPTION
* Endpoints and models updated
* Created `MdmModelChildResource` as base class for child items for a model domain
* Covers Reference Data Types and Enumeration Values (creating)

Related to MauroDataMapper/mdm-ui#642