### PR TITLE
Refactor DataType

### DIFF
--- a/src/data-models/mdm-data-element.model.ts
+++ b/src/data-models/mdm-data-element.model.ts
@@ -27,7 +27,7 @@ import {
   SortParameters,
   Uuid
 } from '../mdm-common.model';
-import { DataTypeReference } from './mdm-data-type.model';
+import { DataType, DataTypeReference } from './mdm-data-type.model';
 
 export type DataElementIndexParameters = SortParameters &
   PageParameters &
@@ -41,7 +41,7 @@ export interface DataElement {
   description?: string;
   model?: Uuid;
   dataClass?: Uuid;
-  dataType?: DataTypeReference;
+  dataType?: DataType | DataTypeReference;
   breadcrumbs?: Breadcrumb[];
   minMultiplicity?: number;
   maxMultipicity?: number;

--- a/src/data-models/mdm-data-element.resource.ts
+++ b/src/data-models/mdm-data-element.resource.ts
@@ -128,7 +128,9 @@ export class MdmDataElementResource extends MdmResource {
   }
 
   /**
-   * `HTTP PUT` - Updates an existing data element under a chosen data class.
+   * `HTTP PUT` - Updates an existing data element under a chosen data class. It can create new 
+   * {@link DataType} if the {@link DataElement} contains a complete {@link DataType} instead
+   * of using a {@link DataTypeReference}.
    *
    * @param dataModelId The unique identifier of the data model the data element exists under.
    * @param dataClassId The unique identifier of the data class the data element exists under.

--- a/src/data-models/mdm-data-element.resource.ts
+++ b/src/data-models/mdm-data-element.resource.ts
@@ -128,7 +128,7 @@ export class MdmDataElementResource extends MdmResource {
   }
 
   /**
-   * `HTTP PUT` - Updates an existing data element under a chosen data class. It can create new 
+   * `HTTP PUT` - Updates an existing data element under a chosen data class. It can create new
    * {@link DataType} if the {@link DataElement} contains a complete {@link DataType} instead
    * of using a {@link DataTypeReference}.
    *

--- a/src/data-models/mdm-data-type.model.ts
+++ b/src/data-models/mdm-data-type.model.ts
@@ -59,11 +59,10 @@ export interface DataTypeProvider {
 }
 
 export interface DataTypeReference {
-  [key: string]: any;
   id: Uuid;
 }
 
-export interface DataType {
+export interface BaseDataType {
   [key: string]: any;
   id?: Uuid;
   domainType: CatalogueItemDomainType;
@@ -71,10 +70,23 @@ export interface DataType {
   description?: string;
   model?: Uuid;
   breadcrumbs?: Breadcrumb[];
-  enumerationValues?: EnumerationValue[];
-  referenceClass?: ReferenceClass;
   classifiers?: CatalogueItemReference[];
 }
+
+export interface ModelType {
+  modelResourceId?: Uuid;
+  modelResourceDomainType?: CatalogueItemDomainType;
+}
+
+export interface EnumerationType {
+  enumerationValues?: EnumerationValue[];
+}
+
+export interface ReferenceType {
+  referenceClass?: ReferenceClass;
+}
+
+export type DataType = BaseDataType & ModelType & EnumerationType & ReferenceType;
 
 export type DataTypeDetail = DataType & Securable & Historical;
 

--- a/src/data-models/mdm-data-type.model.ts
+++ b/src/data-models/mdm-data-type.model.ts
@@ -63,7 +63,6 @@ export interface DataTypeReference {
 }
 
 export interface BaseDataType {
-  [key: string]: any;
   id?: Uuid;
   domainType: CatalogueItemDomainType;
   label: string;


### PR DESCRIPTION
Investigation over [MauroDataMapper/mdm-ui/318](https://github.com/MauroDataMapper/mdm-ui/issues/318) concluded that the cause of the problem was that we were passing the correct data under the wrong name, and therefore, the backend was unable to process the request. This happened because 2 reasons:
- In the ui the component to create new `DataTypes `inline had the wrong names of variables, and the components calling that one were not processing correctly the outcome of it before sending.
- The definition of a `DataType `in this repo (resources) is not aligned with the types in the backend and had a property that allowed us to place whatever variable we want within a `DataType `without getting a compiler error.

Thus, this PR is to address the second point, I have done the following:
- Refactor `DataType `to match closely the `DataType `definition of the backend in the core.
- Removed the "all allowed" property in the `DataType `definition.