### PR TITLE
Feature/gh 116 support for copy endpoints

### DIFF
--- a/src/data-models/mdm-data-class.model.ts
+++ b/src/data-models/mdm-data-class.model.ts
@@ -68,8 +68,6 @@ export interface DataClassNode {
 }
 
 export interface CopyDataClassPayload extends Payload{
-  targetDataModelId: Uuid;
-  sourceDataModelId: Uuid;
   copyLabel : string;
   copyPermissions: boolean;
 }

--- a/src/data-models/mdm-data-class.model.ts
+++ b/src/data-models/mdm-data-class.model.ts
@@ -23,6 +23,7 @@ import {
   MdmIndexResponse,
   MdmResponse,
   PageParameters,
+  Payload,
   QueryParameters,
   SortParameters,
   Uuid
@@ -64,6 +65,11 @@ export interface DataClassNode {
    * The Data Elements under this Data Class.
    */
   dataElements?: DataElementDetail[];
+}
+
+export interface CopyDataClassPayload extends Payload{
+  targetDataModelId: Uuid;
+  sourceDataModelId: Uuid;
 }
 
 export type DataClassFull = DataClassDetail & DataClassNode;

--- a/src/data-models/mdm-data-class.model.ts
+++ b/src/data-models/mdm-data-class.model.ts
@@ -70,6 +70,8 @@ export interface DataClassNode {
 export interface CopyDataClassPayload extends Payload{
   targetDataModelId: Uuid;
   sourceDataModelId: Uuid;
+  copyLabel : string;
+  copyPermissions: boolean;
 }
 
 export type DataClassFull = DataClassDetail & DataClassNode;

--- a/src/data-models/mdm-data-class.resource.ts
+++ b/src/data-models/mdm-data-class.resource.ts
@@ -21,7 +21,7 @@ import {
   Uuid,
   SearchQueryParameters
 } from '../mdm-common.model';
-import { DataClass, DataClassIndexParameters } from './mdm-data-class.model';
+import { CopyDataClassPayload, DataClass, DataClassIndexParameters } from './mdm-data-class.model';
 import { MdmResource } from '../mdm-resource';
 
 /**
@@ -499,4 +499,19 @@ export class MdmDataClassResource extends MdmResource {
     const url = `${this.apiEndpoint}/dataModels/${dataModelId}/dataClasses/${dataClassId}/extends/${otherDataModelId}/${otherDataClassId}`;
     return this.simpleDelete(url, {}, options);
   }
+
+  /*
+    * `HTTP POST` - Copy a data class from a source data model to a target data model.
+    *
+    * @param CopyDataClassPyaload The payload of the request containing the source and target data model and data class IDs.
+    * @returns The result of the `POST` request.
+    *
+    * `200 OK` - will return a {@link DataClassDetailResponse} containing a {@link DataClassDetail} object.
+  */
+
+  copy(dataClassId: Uuid, copyDataClassPayload: CopyDataClassPayload){
+    const url = `${this.apiEndpoint}/dataModels/${copyDataClassPayload.targetDataModelId}/dataClasses/${copyDataClassPayload.sourceDataModelId}/${dataClassId}`;
+    return this.simplePost(url, {}, {});
+  }
+
 }

--- a/src/data-models/mdm-data-class.resource.ts
+++ b/src/data-models/mdm-data-class.resource.ts
@@ -21,7 +21,11 @@ import {
   Uuid,
   SearchQueryParameters
 } from '../mdm-common.model';
-import { CopyDataClassPayload, DataClass, DataClassIndexParameters } from './mdm-data-class.model';
+import {
+  CopyDataClassPayload,
+  DataClass,
+  DataClassIndexParameters
+} from './mdm-data-class.model';
 import { MdmResource } from '../mdm-resource';
 
 /**
@@ -500,18 +504,26 @@ export class MdmDataClassResource extends MdmResource {
     return this.simpleDelete(url, {}, options);
   }
 
-  /*
-    * `HTTP POST` - Copy a data class from a source data model to a target data model.
-    *
-    * @param CopyDataClassPyaload The payload of the request containing the source and target data model and data class IDs.
-    * @returns The result of the `POST` request.
-    *
-    * `200 OK` - will return a {@link DataClassDetailResponse} containing a {@link DataClassDetail} object.
-  */
-
-  copy(dataClassId: Uuid, copyDataClassPayload: CopyDataClassPayload){
-    const url = `${this.apiEndpoint}/dataModels/${copyDataClassPayload.targetDataModelId}/dataClasses/${copyDataClassPayload.sourceDataModelId}/${dataClassId}`;
-    return this.simplePost(url, copyDataClassPayload);
+  /**
+   * `HTTP POST` - Copy a data class from one data model to another.
+   *
+   * @param targetDataModelId The unique identifier of the target data model.
+   * @param sourceDataModelId The unique identifier of the source data model.
+   * @param dataClassId The unique identifier of the data class to copy.
+   * @param copyDataClassPayload The payload of the request containing the details of the data class to copy.
+   * @param options Optional REST handler parameters, if required.
+   * @returns The result of the `POST` request.
+   *
+   * `200 OK` - will return a {@link DataClassDetailResponse} containing a {@link DataClassDetail} object
+   **/
+  copy(
+    targetDataModelId: Uuid,
+    sourceDataModelId: Uuid,
+    dataClassId: Uuid,
+    copyDataClassPayload: CopyDataClassPayload,
+    options?: RequestSettings
+  ) {
+    const url = `${this.apiEndpoint}/dataModels/${targetDataModelId}/dataClasses/${sourceDataModelId}/${dataClassId}`;
+    return this.simplePost(url, copyDataClassPayload, options);
   }
-
 }

--- a/src/data-models/mdm-data-class.resource.ts
+++ b/src/data-models/mdm-data-class.resource.ts
@@ -511,7 +511,7 @@ export class MdmDataClassResource extends MdmResource {
 
   copy(dataClassId: Uuid, copyDataClassPayload: CopyDataClassPayload){
     const url = `${this.apiEndpoint}/dataModels/${copyDataClassPayload.targetDataModelId}/dataClasses/${copyDataClassPayload.sourceDataModelId}/${dataClassId}`;
-    return this.simplePost(url, {}, {});
+    return this.simplePost(url, copyDataClassPayload);
   }
 
 }

--- a/src/data-models/mdm-data-element.model.ts
+++ b/src/data-models/mdm-data-element.model.ts
@@ -23,6 +23,7 @@ import {
   MdmIndexResponse,
   MdmResponse,
   PageParameters,
+  Payload,
   QueryParameters,
   SortParameters,
   Uuid
@@ -45,6 +46,17 @@ export interface DataElement {
   breadcrumbs?: Breadcrumb[];
   minMultiplicity?: number;
   maxMultipicity?: number;
+}
+
+
+
+export interface CopyDataElementPayload extends Payload {
+
+  targetDataModelId: Uuid;
+  targetDataClassId: Uuid;
+  sourceDataModelId: Uuid;
+  sourceDataClassId: Uuid;
+
 }
 
 export type DataElementDetail = DataElement & Securable & Historical;

--- a/src/data-models/mdm-data-element.model.ts
+++ b/src/data-models/mdm-data-element.model.ts
@@ -51,11 +51,6 @@ export interface DataElement {
 
 
 export interface CopyDataElementPayload extends Payload {
-
-  targetDataModelId: Uuid;
-  targetDataClassId: Uuid;
-  sourceDataModelId: Uuid;
-  sourceDataClassId: Uuid;
   copyLabel : string;
   copyPermissions: boolean;
 }

--- a/src/data-models/mdm-data-element.model.ts
+++ b/src/data-models/mdm-data-element.model.ts
@@ -56,7 +56,8 @@ export interface CopyDataElementPayload extends Payload {
   targetDataClassId: Uuid;
   sourceDataModelId: Uuid;
   sourceDataClassId: Uuid;
-
+  copyLabel : string;
+  copyPermissions: boolean;
 }
 
 export type DataElementDetail = DataElement & Securable & Historical;

--- a/src/data-models/mdm-data-element.resource.ts
+++ b/src/data-models/mdm-data-element.resource.ts
@@ -17,6 +17,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { RequestSettings, QueryParameters, Uuid } from '../mdm-common.model';
 import {
+  CopyDataElementPayload,
   DataElement,
   DataElementIndexParameters
 } from './mdm-data-element.model';
@@ -208,5 +209,18 @@ export class MdmDataElementResource extends MdmResource {
   ) {
     const url = `${this.apiEndpoint}/dataModels/${dataModelId}/dataClasses/${dataClassId}/dataElements/${otherDataModelId}/${otherDataClassId}/${dataElementId}`;
     return this.simplePost(url, {}, options);
+  }
+
+  /**
+   * `HTTP POST` - Same as above but takes a payload object instead of individual parameters.
+   *
+   * @param dataElementId The unique identifier of the data element to copy.
+   * @param copyDataElementPayload The payload object containing the source and target data model and data class identifiers.
+   *
+   * `200 OK` - will return a {@link DataElementDetailResponse} containing the new copy of a {@link DataElementDetail} object.
+   */
+  copy(dataElementId: Uuid, copyDataElementPayload: CopyDataElementPayload) {
+    const url = `${this.apiEndpoint}/dataModels/${copyDataElementPayload.targetDataModelId}/dataClasses/${copyDataElementPayload.targetDataClassId}/dataElements/${copyDataElementPayload.otherDataModelId}/${copyDataElementPayload.sourceDataClassId}/${dataElementId}`;
+    return this.simplePost(url, {}, {});
   }
 }

--- a/src/data-models/mdm-data-element.resource.ts
+++ b/src/data-models/mdm-data-element.resource.ts
@@ -220,7 +220,7 @@ export class MdmDataElementResource extends MdmResource {
    * `200 OK` - will return a {@link DataElementDetailResponse} containing the new copy of a {@link DataElementDetail} object.
    */
   copy(dataElementId: Uuid, copyDataElementPayload: CopyDataElementPayload) {
-    const url = `${this.apiEndpoint}/dataModels/${copyDataElementPayload.targetDataModelId}/dataClasses/${copyDataElementPayload.targetDataClassId}/dataElements/${copyDataElementPayload.otherDataModelId}/${copyDataElementPayload.sourceDataClassId}/${dataElementId}`;
+    const url = `${this.apiEndpoint}/dataModels/${copyDataElementPayload.targetDataModelId}/dataClasses/${copyDataElementPayload.targetDataClassId}/dataElements/${copyDataElementPayload.sourceDataClassId}/${dataElementId}`;
     return this.simplePost(url, {}, {});
   }
 }

--- a/src/data-models/mdm-data-element.resource.ts
+++ b/src/data-models/mdm-data-element.resource.ts
@@ -205,26 +205,37 @@ export class MdmDataElementResource extends MdmResource {
     otherDataModelId: Uuid,
     otherDataClassId: Uuid,
     dataElementId: Uuid,
-    options?: RequestSettings,
+    options?: RequestSettings
   ) {
     const url = `${this.apiEndpoint}/dataModels/${dataModelId}/dataClasses/${dataClassId}/dataElements/${otherDataModelId}/${otherDataClassId}/${dataElementId}`;
     return this.simplePost(url, {}, options);
   }
 
   /**
-   * `HTTP POST` - Same as above but takes a payload object instead of individual parameters, allows renaming of copy.
+   * `HTTP POST` - Copies an existing data element from one data class to another target data class.
+   * This method allows for the copying of a data element with a new label and permissions.
    *
-   * @param dataElementId The unique identifier of the data element to copy.
-   * @param copyDataElementPayload The payload object containing the source and target data model and data class identifiers.
+   * @param targetDataModelId The unique identifier of the target data model
+   * @param targetDataClassId The unique identifier of the target data class
+   * @param sourceDataModelId The unique identifier of the source data model
+   * @param sourceDataClassId The unique identifier of the source data class
+   * @param dataElementId The unique identifier of the data element to copy
+   * @param copyDataElementPayload The payload of the request containing the new label and permissions
+   * @param options Optional REST handler parameters, if required
+   * @returns The result of the `POST` request
    *
    * `200 OK` - will return a {@link DataElementDetailResponse} containing the new copy of a {@link DataElementDetail} object.
-   */
+   **/
   copy(
+    targetDataModelId: Uuid,
+    targetDataClassId: Uuid,
+    sourceDataModelId: Uuid,
+    sourceDataClassId: Uuid,
     dataElementId: Uuid,
     copyDataElementPayload: CopyDataElementPayload,
     options?: RequestSettings
   ) {
-    const url = `${this.apiEndpoint}/dataModels/${copyDataElementPayload.sourceDataModelId}/dataClasses/${copyDataElementPayload.sourceDataClassId}/dataElements/${copyDataElementPayload.targetDataModelId}/${copyDataElementPayload.targetDataClassId}/${dataElementId}`;
+    const url = `${this.apiEndpoint}/dataModels/${sourceDataModelId}/dataClasses/${sourceDataClassId}/dataElements/${targetDataModelId}/${targetDataClassId}/${dataElementId}`;
     return this.simplePost(url, copyDataElementPayload, options);
   }
 }

--- a/src/data-models/mdm-data-element.resource.ts
+++ b/src/data-models/mdm-data-element.resource.ts
@@ -205,22 +205,26 @@ export class MdmDataElementResource extends MdmResource {
     otherDataModelId: Uuid,
     otherDataClassId: Uuid,
     dataElementId: Uuid,
-    options?: RequestSettings
+    options?: RequestSettings,
   ) {
     const url = `${this.apiEndpoint}/dataModels/${dataModelId}/dataClasses/${dataClassId}/dataElements/${otherDataModelId}/${otherDataClassId}/${dataElementId}`;
     return this.simplePost(url, {}, options);
   }
 
   /**
-   * `HTTP POST` - Same as above but takes a payload object instead of individual parameters.
+   * `HTTP POST` - Same as above but takes a payload object instead of individual parameters, allows renaming of copy.
    *
    * @param dataElementId The unique identifier of the data element to copy.
    * @param copyDataElementPayload The payload object containing the source and target data model and data class identifiers.
    *
    * `200 OK` - will return a {@link DataElementDetailResponse} containing the new copy of a {@link DataElementDetail} object.
    */
-  copy(dataElementId: Uuid, copyDataElementPayload: CopyDataElementPayload) {
-    const url = `${this.apiEndpoint}/dataModels/${copyDataElementPayload.targetDataModelId}/dataClasses/${copyDataElementPayload.targetDataClassId}/dataElements/${copyDataElementPayload.sourceDataClassId}/${dataElementId}`;
-    return this.simplePost(url, {}, {});
+  copy(
+    dataElementId: Uuid,
+    copyDataElementPayload: CopyDataElementPayload,
+    options?: RequestSettings
+  ) {
+    const url = `${this.apiEndpoint}/dataModels/${copyDataElementPayload.sourceDataModelId}/dataClasses/${copyDataElementPayload.sourceDataClassId}/dataElements/${copyDataElementPayload.targetDataModelId}/${copyDataElementPayload.targetDataClassId}/${dataElementId}`;
+    return this.simplePost(url, copyDataElementPayload, options);
   }
 }

--- a/src/data-models/mdm-data-element.resource.ts
+++ b/src/data-models/mdm-data-element.resource.ts
@@ -219,8 +219,8 @@ export class MdmDataElementResource extends MdmResource {
    * @param targetDataClassId The unique identifier of the target data class
    * @param sourceDataModelId The unique identifier of the source data model
    * @param sourceDataClassId The unique identifier of the source data class
-   * @param dataElementId The unique identifier of the data element to copy
-   * @param copyDataElementPayload The payload of the request containing the new label and permissions
+   * @param sourceDataElementId The unique identifier of the data element to copy
+   * @param payload The payload of the request containing the new label and permissions
    * @param options Optional REST handler parameters, if required
    * @returns The result of the `POST` request
    *
@@ -231,11 +231,11 @@ export class MdmDataElementResource extends MdmResource {
     targetDataClassId: Uuid,
     sourceDataModelId: Uuid,
     sourceDataClassId: Uuid,
-    dataElementId: Uuid,
-    copyDataElementPayload: CopyDataElementPayload,
+    sourceDataElementId: Uuid,
+    payload: CopyDataElementPayload,
     options?: RequestSettings
   ) {
-    const url = `${this.apiEndpoint}/dataModels/${sourceDataModelId}/dataClasses/${sourceDataClassId}/dataElements/${targetDataModelId}/${targetDataClassId}/${dataElementId}`;
-    return this.simplePost(url, copyDataElementPayload, options);
+    const url = `${this.apiEndpoint}/dataModels/${targetDataModelId}/dataClasses/${targetDataClassId}/dataElements/${sourceDataModelId}/${sourceDataClassId}/${sourceDataElementId}`;
+    return this.simplePost(url, payload, options);
   }
 }

--- a/src/data-models/mdm-data-model.model.ts
+++ b/src/data-models/mdm-data-model.model.ts
@@ -152,3 +152,7 @@ export interface SimpleModelVersionTree {
   id: Uuid;
   modelVersion?: string;
 }
+
+
+
+

--- a/src/data-models/mdm-data-model.resource.ts
+++ b/src/data-models/mdm-data-model.resource.ts
@@ -31,6 +31,7 @@ import {
 } from './mdm-data-model.model';
 import { MdmModelDomainResource } from '../mdm-model-types.resource';
 import { MdmResourcesConfiguration, MdmRestHandler } from '../mdm-resource';
+import { CopyContainerPayload } from '../mdm-container-types.model';
 
 /**
  * MDM resource for managing data models.
@@ -535,4 +536,22 @@ export class MdmDataModelResource extends MdmModelDomainResource {
     const url = `${this.apiEndpoint}/dataModels/${sourceId}/intersectsMany`;
     return this.simplePost(url, data, options);
   }
+
+  /**
+   * `HTTP PUT` - Copy a Data Model to another Data Model. Define the target folder and the name of the new Data Model.
+   *
+   * @param dataModelId The unique identifier of the Data Model to copy.
+   * @param CopyContainerPayload The payload containing details on where to copy the Data Model to.
+   * @returns The result of the `PUT` request.
+   *
+   * `200 OK` - will return a {@link DataModelDetailResponse} containing a {@link DataModelDetail
+   */
+  copy(
+    dataModelId: Uuid,
+    copyContainerPayload: CopyContainerPayload
+  ) {
+    const url = `${this.apiEndpoint}/dataModels/${dataModelId}/copy`;
+    return this.simplePut(url, copyContainerPayload);
+  }
 }
+

--- a/src/data-models/mdm-data-model.resource.ts
+++ b/src/data-models/mdm-data-model.resource.ts
@@ -31,7 +31,7 @@ import {
 } from './mdm-data-model.model';
 import { MdmModelDomainResource } from '../mdm-model-types.resource';
 import { MdmResourcesConfiguration, MdmRestHandler } from '../mdm-resource';
-import { CopyContainerPayload } from '../mdm-container-types.model';
+import { CopyModelPayload } from '../mdm-container-types.model';
 
 /**
  * MDM resource for managing data models.
@@ -540,18 +540,19 @@ export class MdmDataModelResource extends MdmModelDomainResource {
   /**
    * `HTTP PUT` - Copy a Data Model to another Data Model. Define the target folder and the name of the new Data Model.
    *
-   * @param dataModelId The unique identifier of the Data Model to copy.
-   * @param CopyContainerPayload The payload containing details on where to copy the Data Model to.
+   * @param sourceDataModelId The unique identifier of the Data Model to copy.
+   * @param copyModelPayload The payload containing details on where to copy the Data Model to.
    * @returns The result of the `PUT` request.
    *
    * `200 OK` - will return a {@link DataModelDetailResponse} containing a {@link DataModelDetail
    */
   copy(
-    dataModelId: Uuid,
-    copyContainerPayload: CopyContainerPayload
+    sourceDataModelId: Uuid,
+    copyModelPayload: CopyModelPayload,
+    options?: RequestSettings
   ) {
-    const url = `${this.apiEndpoint}/dataModels/${dataModelId}/copy`;
-    return this.simplePut(url, copyContainerPayload);
+    const url = `${this.apiEndpoint}/dataModels/${sourceDataModelId}/copy`;
+    return this.simplePut(url, copyModelPayload, options);
   }
 }
 

--- a/src/mdm-container-types.model.ts
+++ b/src/mdm-container-types.model.ts
@@ -47,7 +47,7 @@ export interface ContainerUpdatePayload extends Payload {
 /**
  * Represents the payload to copy a data model.
  */
-export interface CopyContainerPayload extends Payload {
+export interface CopyModelPayload extends Payload {
   /**
    * The target folder to copy the data model to.
    */
@@ -59,6 +59,6 @@ export interface CopyContainerPayload extends Payload {
   /**
    * Flag to indicate if permissions should be copied.
    */
-  copyPermissions: Boolean;
+  copyPermissions: boolean;
 
 }

--- a/src/mdm-container-types.model.ts
+++ b/src/mdm-container-types.model.ts
@@ -43,3 +43,22 @@ export interface ContainerUpdatePayload extends Payload {
   label?: string;
   description?: string;
 }
+
+/**
+ * Represents the payload to copy a data model.
+ */
+export interface CopyContainerPayload extends Payload {
+  /**
+   * The target folder to copy the data model to.
+   */
+  folderId: Uuid;
+  /**
+   * The name of the target data model.
+   */
+  label: string;
+  /**
+   * Flag to indicate if permissions should be copied.
+   */
+  copyPermissions: Boolean;
+
+}

--- a/src/terminologies/mdm-code-set.resource.ts
+++ b/src/terminologies/mdm-code-set.resource.ts
@@ -21,6 +21,7 @@ import { RequestSettings, QueryParameters, Uuid } from '../mdm-common.model';
 import { CodeSetCreatePayload } from './mdm-code-set.model';
 import { MdmModelDomainResource } from '../mdm-model-types.resource';
 import { MdmResourcesConfiguration, MdmRestHandler } from '../mdm-resource';
+import { CopyContainerPayload } from '../mdm-container-types.model';
 
 /**
  * MDM resources for the management of code sets.
@@ -249,5 +250,21 @@ export class MdmCodeSetResource extends MdmModelDomainResource {
   undoSoftDelete(codeSetId: Uuid, options?: RequestSettings) {
     const url = `${this.apiEndpoint}/admin/codeSets/${codeSetId}/undoSoftDelete`;
     return this.simplePut(url, {}, options);
+  }
+
+  /**
+   * `HTTP PUT` - Copy a code set.
+   *
+   * @param codeSetId The unique identifier of the code set to copy.
+   * @param CopyContainerPayload The payload to pass to the request when copying the code set.
+   * @returns The result of the `PUT` request.
+   *
+   * `200 OK` - will return a {@link CodeSetDetailResponse} containing a {@link CodeSetDetail} object.
+   */
+  copy(codeSetId: Uuid,
+    copyContainerPayload: CopyContainerPayload
+  ){
+    const url = `${this.apiEndpoint}/codeSets/${codeSetId}/copy`;
+    return this.simplePut(url, copyContainerPayload);
   }
 }

--- a/src/terminologies/mdm-code-set.resource.ts
+++ b/src/terminologies/mdm-code-set.resource.ts
@@ -21,7 +21,7 @@ import { RequestSettings, QueryParameters, Uuid } from '../mdm-common.model';
 import { CodeSetCreatePayload } from './mdm-code-set.model';
 import { MdmModelDomainResource } from '../mdm-model-types.resource';
 import { MdmResourcesConfiguration, MdmRestHandler } from '../mdm-resource';
-import { CopyContainerPayload } from '../mdm-container-types.model';
+import { CopyModelPayload } from '../mdm-container-types.model';
 
 /**
  * MDM resources for the management of code sets.
@@ -255,16 +255,16 @@ export class MdmCodeSetResource extends MdmModelDomainResource {
   /**
    * `HTTP PUT` - Copy a code set.
    *
-   * @param codeSetId The unique identifier of the code set to copy.
+   * @param sourceCodeSetId The unique identifier of the code set to copy.
    * @param CopyContainerPayload The payload to pass to the request when copying the code set.
    * @returns The result of the `PUT` request.
    *
    * `200 OK` - will return a {@link CodeSetDetailResponse} containing a {@link CodeSetDetail} object.
    */
-  copy(codeSetId: Uuid,
-    copyContainerPayload: CopyContainerPayload
+  copy(sourceCodeSetId: Uuid,
+    copyModelPayload: CopyModelPayload
   ){
-    const url = `${this.apiEndpoint}/codeSets/${codeSetId}/copy`;
-    return this.simplePut(url, copyContainerPayload);
+    const url = `${this.apiEndpoint}/codeSets/${sourceCodeSetId}/copy`;
+    return this.simplePut(url, copyModelPayload);
   }
 }

--- a/src/terminologies/mdm-term.resource.ts
+++ b/src/terminologies/mdm-term.resource.ts
@@ -38,6 +38,8 @@ import { CopyTermPayload } from './mdm-terminology.model';
  |   PUT    | /api/terminologies/${terminologyId}/terms/${id}                                                            | Action: update                                  |
  |   GET    | /api/terminologies/${terminologyId}/terms/${id}                                                            | Action: show
  |   GET    | /api/terminologies/${terminologyId}/terms/${id}/codeSets                                                   | Action: show
+ |   POST   | /api/terminologies/${terminologyId}/terms/${id}/copy                                                       | Action: copy
+                |
  *
  * Controller: termRelationship
  |   GET    | /api/terminologies/${terminologyId}/termRelationshipTypes/${termRelationshipTypeId}/termRelationships            | Action: index                                   |

--- a/src/terminologies/mdm-term.resource.ts
+++ b/src/terminologies/mdm-term.resource.ts
@@ -256,23 +256,22 @@ export class MdmTermResource extends MdmResource {
     return this.simpleGet(url, queryStringParams, restHandlerOptions);
   }
 
-  /*
-    * `HTTP POST` - Copy a term.
-    *
-    * @param terminologyId The unique identifier of the terminology to copy the term to.
-    * @param termId The unique identifier of the term to copy.
-    * @param copyTermPayload The payload of the request containing all the details for the term to copy.
-    * @returns The result of the `POST` request.
-    *
-    * `200 OK` - will return a {@link TermDetailResponse} containing a {@link TermDetail} object.
-  */
+  /**
+   * `HTTP POST` - Copy a term.
+   *
+   * @param sourceTerminologyId The unique identifier of the terminology to copy the term to.
+   * @param termId The unique identifier of the term to copy.
+   * @param copyTermPayload The payload of the request containing all the details for the term to copy.
+   * @returns The result of the `POST` request.
+   *
+   * `200 OK` - will return a {@link TermDetailResponse} containing a {@link TermDetail} object.
+   **/
   copy(
-    terminologyId: Uuid,
-    termId: Uuid,
+    sourceTerminologyId: Uuid,
+    sourceTermId: Uuid,
     copyTermPayload: CopyTermPayload
   ) {
-    const url = `${this.apiEndpoint}/terminologies/${terminologyId}/terms/copy/${termId}`;
+    const url = `${this.apiEndpoint}/terminologies/${sourceTerminologyId}/terms/copy/${sourceTermId}`;
     return this.simplePut(url, copyTermPayload);
   }
-
 }

--- a/src/terminologies/mdm-term.resource.ts
+++ b/src/terminologies/mdm-term.resource.ts
@@ -24,6 +24,7 @@ import {
   SearchQueryParameters
 } from '../mdm-common.model';
 import { MdmResource } from '../mdm-resource';
+import { CopyTermPayload } from './mdm-terminology.model';
 
 /**
  * Controller: term
@@ -252,4 +253,24 @@ export class MdmTermResource extends MdmResource {
     const url = `${this.apiEndpoint}/terminologies/${terminologyId}/terms/${termId}/codeSets`;
     return this.simpleGet(url, queryStringParams, restHandlerOptions);
   }
+
+  /*
+    * `HTTP POST` - Copy a term.
+    *
+    * @param terminologyId The unique identifier of the terminology to copy the term to.
+    * @param termId The unique identifier of the term to copy.
+    * @param copyTermPayload The payload of the request containing all the details for the term to copy.
+    * @returns The result of the `POST` request.
+    *
+    * `200 OK` - will return a {@link TermDetailResponse} containing a {@link TermDetail} object.
+  */
+  copy(
+    terminologyId: Uuid,
+    termId: Uuid,
+    copyTermPayload: CopyTermPayload
+  ) {
+    const url = `${this.apiEndpoint}/terminologies/${terminologyId}/terms/copy/${termId}`;
+    return this.simplePut(url, copyTermPayload);
+  }
+
 }

--- a/src/terminologies/mdm-terminology.model.ts
+++ b/src/terminologies/mdm-terminology.model.ts
@@ -16,13 +16,18 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 import { Modelable, ModelDomainDetail } from '../mdm-model-types.model';
-import { MdmIndexResponse, MdmResponse } from '../mdm-common.model';
+import { MdmIndexResponse, MdmResponse, Payload, Uuid } from '../mdm-common.model';
 
 export type TerminologyDataType = 'Terminology';
 
 export interface Terminology extends Modelable {
   [key: string]: any;
   type?: TerminologyDataType;
+}
+
+export interface CopyTermPayload extends Payload{
+  targetTerminologyId: Uuid;
+  code: string;
 }
 
 export type TerminologyDetail = Terminology & ModelDomainDetail;

--- a/src/terminologies/mdm-terminology.resource.ts
+++ b/src/terminologies/mdm-terminology.resource.ts
@@ -19,6 +19,7 @@ import { RequestSettings, QueryParameters, Uuid } from '../mdm-common.model';
 import { FinalisePayload, ModelCreatePayload } from '../mdm-model-types.model';
 import { MdmModelDomainResource } from '../mdm-model-types.resource';
 import { MdmResourcesConfiguration, MdmRestHandler } from '../mdm-resource';
+import { CopyContainerPayload } from '../mdm-container-types.model';
 
 /**
  * MDM resource for the management of terminologies.
@@ -242,5 +243,22 @@ export class MdmTerminologyResource extends MdmModelDomainResource {
   undoSoftDelete(terminologyId: Uuid, options?: RequestSettings) {
     const url = `${this.apiEndpoint}/admin/terminologies/${terminologyId}/undoSoftDelete`;
     return this.simplePut(url, {}, options);
+  }
+
+  /**
+   * `HTTP PUT` - Copies a terminology to a new folder.
+   *
+   * @param terminologyId The unique identifier of the terminology to copy.
+   * @param CopyContainerPayload The payload to pass to the request when copying the terminology.
+   * @returns The result of the `PUT` request.
+   *
+   * `200 OK` - will return a {@link TerminologyDetailResponse} containing a {@link TerminologyDetail} object.
+   */
+  copy(
+    terminologyId: Uuid,
+    copyContainerPayload: CopyContainerPayload
+  ) {
+    const url = `${this.apiEndpoint}/terminologies/${terminologyId}/copy`;
+    return this.simplePut(url, copyContainerPayload);
   }
 }

--- a/src/terminologies/mdm-terminology.resource.ts
+++ b/src/terminologies/mdm-terminology.resource.ts
@@ -19,7 +19,7 @@ import { RequestSettings, QueryParameters, Uuid } from '../mdm-common.model';
 import { FinalisePayload, ModelCreatePayload } from '../mdm-model-types.model';
 import { MdmModelDomainResource } from '../mdm-model-types.resource';
 import { MdmResourcesConfiguration, MdmRestHandler } from '../mdm-resource';
-import { CopyContainerPayload } from '../mdm-container-types.model';
+import { CopyModelPayload } from '../mdm-container-types.model';
 
 /**
  * MDM resource for the management of terminologies.
@@ -248,17 +248,17 @@ export class MdmTerminologyResource extends MdmModelDomainResource {
   /**
    * `HTTP PUT` - Copies a terminology to a new folder.
    *
-   * @param terminologyId The unique identifier of the terminology to copy.
+   * @param sourceTerminologyId The unique identifier of the terminology to copy.
    * @param CopyContainerPayload The payload to pass to the request when copying the terminology.
    * @returns The result of the `PUT` request.
    *
    * `200 OK` - will return a {@link TerminologyDetailResponse} containing a {@link TerminologyDetail} object.
    */
   copy(
-    terminologyId: Uuid,
-    copyContainerPayload: CopyContainerPayload
+    sourceTerminologyId: Uuid,
+    copyModelPayload: CopyModelPayload
   ) {
-    const url = `${this.apiEndpoint}/terminologies/${terminologyId}/copy`;
-    return this.simplePut(url, copyContainerPayload);
+    const url = `${this.apiEndpoint}/terminologies/${sourceTerminologyId}/copy`;
+    return this.simplePut(url, copyModelPayload);
   }
 }


### PR DESCRIPTION
Support PullRequest adding the copy endpoints and payload models for dataModel/DataElement/DataClass, Terminology/Term and CodeSet

Supports: https://github.com/MauroDataMapper/mdm-ui/compare/feature-gh-861-copy-items-ui?expand=1

closes #116 